### PR TITLE
Add gitignore to remove doc/tags generated file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
Hello,

I added this .gitignore which seems to be quite common so that when this plugin is used as a git submodule, the generated file is not taken into account.

Regards,
Laurent
