### PR TITLE
Escape python filename with fnameescape()

### DIFF
--- a/autoload/gundo.vim
+++ b/autoload/gundo.vim
@@ -283,7 +283,7 @@ function! s:GundoOpen()"{{{
             exe 'py3file ' . s:plugin_path . '/gundo.py'
             python3 initPythonModule()
         else
-            exe 'pyfile ' . s:plugin_path . '/gundo.py'
+            exe 'pyfile ' . fnameescape(s:plugin_path . '/gundo.py')
             python initPythonModule()
         endif
 


### PR DESCRIPTION
I ran into `E172` when attempting to use Gundo in Vim under Cygwin. The error happens when the path to `gundo.py` is in a directory with spaces in it, which is exactly the type of situation where `fnameescape()` is useful.
